### PR TITLE
Hopefully truly fixes S3 uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+PYTHONPATH=./app:$PYTHONPATH
+FLASK_APP=server.app:app
+AWS_ACCESS_KEY_ID=<access_key_id>
+AWS_SECRET_ACCESS_KEY=<access_key>
+AWS_DEFAULT_REGION=us-east-1

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ htmlcov
 *,cover
 
 node_modules
+.env


### PR DESCRIPTION
Updated S3 folder to have two folders: `examples` and `uploaded`. These changes should allow for uploaded files to go to the appropriate folder and be fetched from their for scanning. I also changed the lifecycle policy on the bucket so that objects in the `uploaded` folder will be deleted after 1 day.